### PR TITLE
Build fixes for recent ArchLinux, Bugfix for devdocs downloads & display, New Feature: FocusOnSummon

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -92,6 +92,10 @@ startGUI config configRoot guiDir slot = do
     , defPropertyRO' "controller"
         (\_obj ->
           return objectController)
+
+    , defPropertyConst' "focusOnSummon"
+        (\_obj ->
+          return $ Config.focusOnSummon config)
     ]
 
   objectContext <- newObject classContext ()

--- a/config.yaml
+++ b/config.yaml
@@ -34,6 +34,14 @@ LeftColumnWidthHoogle: 700
 # Restart all instances of this application after changing.
 Port: 7701
 
+# Whether the Window should capture focus on remote summons.
+# ============================================================
+# If set, the doc-browser-window will be raised and receive
+# keyboard forcus. Otherwise, the window will be merely alerted.
+# This might be desireable if you usually have the window
+# opened on a second output and usually find what you are
+# searching for in the first match
+FocusOnSummon: True
 
 # Directory that contains the MathJax distribution.
 # ============================================================

--- a/package.yaml
+++ b/package.yaml
@@ -9,6 +9,9 @@ synopsis:       A documentation browser
 category:       Application
 description:    Please see the README on Github at <https://github.com/qwfy/doc-browser#readme>
 
+build-tools:
+- c2hs >= 0.28.8
+
 extra-source-files:
 - README.asciidoc
 

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -45,6 +45,8 @@ data T = T
   { webEngineZoomFactor :: Float
   , port :: Int
 
+  , focusOnSummon :: Bool
+
   , inputFont           :: Font
   , matchFontMain       :: Font
   , matchFontMainHoogle :: Font

--- a/src/DevDocsMeta.hs
+++ b/src/DevDocsMeta.hs
@@ -101,7 +101,7 @@ match allMetas ccvs = map find ccvs
       compare (metaSortKey m1) (metaSortKey m2)
 
 toDownloadUrl Meta{metaSlug} =
-  concat ["http://dl.devdocs.io/", Text.unpack metaSlug, ".tar.gz"]
+  concat ["https://downloads.devdocs.io/", Text.unpack metaSlug, ".tar.gz"]
 
 typeMap :: Map.Map Doc.Collection String
 typeMap = Map.fromList

--- a/src/Server.hs
+++ b/src/Server.hs
@@ -20,7 +20,7 @@ module Server
 
 import Network.Wai
 import Network.HTTP.Types
-import Network.Wai.Handler.Warp (run)
+import Network.Wai.Handler.Warp (runSettings, setPort, setHost, defaultSettings)
 import Network.Wai.Middleware.RequestLogger
 
 import Data.Monoid
@@ -81,7 +81,8 @@ start logging config configRoot cacheRoot slot = do
     let middleware = case logging of
           Opt.NoLog -> id
           Opt.Log -> logStdout
-    run (Config.port config) (middleware $ app config configRoot cacheRoot slot)
+    let settings = setPort (Config.port config) $ setHost "127.0.0.1" defaultSettings
+    runSettings settings (middleware $ app config configRoot cacheRoot slot)
 
 type API = PublicAPI :<|> PrivateAPI
 

--- a/src/Server.hs
+++ b/src/Server.hs
@@ -315,11 +315,16 @@ fetchDevdocs configRoot cacheRoot collection version path = do
   content <- Builder.fromLazyByteString <$> LBS.readFile (toFilePath filePath)
 
   cssUrl <- getCached cacheRoot "https://devdocs.io/application.css" "css"
+  jsUrl <- getCached cacheRoot "https://raw.githubusercontent.com/freeCodeCamp/devdocs/main/assets/javascripts/vendor/prism.js" "js"
   let css = "<link rel='stylesheet' href='" <> cssUrl <> "'>"
+  let js  = "<script src='" <> jsUrl <> "'></script>" <> "\
+    \ <script>document.querySelectorAll('pre[data-language]').forEach(\
+    \   function(node) { node.classList.add('language-' + node.getAttribute('data-language')); Prism.highlightElement(node);}\
+    \ )</script>"
 
   -- TODO @incomplete: handle the concatenation properly
   let begin' =
-        "<html>\
+        "<html class='_theme-default'>\
         \<head>\
         \  <meta charset='utf-8'>\
         \ " <> css <> "\
@@ -334,9 +339,10 @@ fetchDevdocs configRoot cacheRoot collection version path = do
             Data.String.fromString $ "<div class='_page _" ++ t ++ "'>"
       begin = Builder.fromLazyByteString $ begin' <> pageDiv
 
-  let end = Builder.fromLazyByteString
+  let end = Builder.fromLazyByteString $
         "    </div>\
         \  </main>\
+        \ " <> js <> "\
         \</body>\
         \</html>"
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,3 +5,5 @@ packages:
 
 extra-deps:
 - hsqml-0.3.5.1
+- c2hs-0.28.8
+- language-c-0.9.0.1

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,17 +3,31 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: hsqml-0.3.5.1@sha256:f8b06c0e5def57362345bd39de63acf177dc666ceebae64b7720d62d3a4631b8,5202
-    pantry-tree:
-      size: 3160
-      sha256: e85c53364989fb682e646435c4d7e144e69eee907c72225017e9118d7bcd7d14
-  original:
-    hackage: hsqml-0.3.5.1
 snapshots:
-- completed:
-    size: 506659
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/11/3.yaml
+- original: lts-11.3
+  completed:
     sha256: 4a02ab9386e5968c58529fdf79707ccd0ae1352c213e28a78ee9e0d836be1824
-  original: lts-11.3
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/11/3.yaml
+    size: 506659
+packages:
+- original:
+    hackage: hsqml-0.3.5.1
+  completed:
+    pantry-tree:
+      sha256: e85c53364989fb682e646435c4d7e144e69eee907c72225017e9118d7bcd7d14
+      size: 3160
+    hackage: hsqml-0.3.5.1@sha256:f8b06c0e5def57362345bd39de63acf177dc666ceebae64b7720d62d3a4631b8,5202
+- original:
+    hackage: c2hs-0.28.8
+  completed:
+    pantry-tree:
+      sha256: 37edecd4f2eace540e82d8abc8fb6f5916b9732880ad16a5aa34e0c9b3f77f57
+      size: 17398
+    hackage: c2hs-0.28.8@sha256:980c1a91c93e492d5412e904f2500b2ace34a421e8509529b6d98d89c51f9a2e,9208
+- original:
+    hackage: language-c-0.9.0.1
+  completed:
+    pantry-tree:
+      sha256: 65cf3410da4684205319a8f2dd4cf22edf8b76b1423b62bdbb88a53663cb88ed
+      size: 3496
+    hackage: language-c-0.9.0.1@sha256:7a1c57e8f9c29e94bcd5c748d99e4479a73bd8560cc0affd838f3b2d1bbc0384,4893

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -30,9 +30,13 @@ Window {
 
                 // TODO @incomplete: handle this properly
                 rootWindow.visible = true;
-                rootWindow.visibility = Window.Maximized
-                rootWindow.raise();
-                rootWindow.requestActivate();
+                rootWindow.visibility = Window.Maximized;
+                if (focusOnSummon) {
+                    rootWindow.raise();
+                    rootWindow.requestActivate();
+                } else {
+                    alert(5000);
+                }
             }
         }
     }


### PR DESCRIPTION
Hey,

thank you for the nice and well thought out software. Really improves my dev-experience (especially along with the vim plugin).
However, I had some minor issues with it, that I've fixed. Unfortunately, this means that this PR is sort of a mixed bag. All changes were split into individual commits, but I did not want to create multiple PRs for them. If you don't like any of the changes, just tell me and I will split them out of the changeset into a seperate PR that we can discuss elsewhere.

Changes:
- Buildfixes required for recent Archlinux versions by pulling a gcc11-compliant c2hs version
- Fixing devdocs download by using their new urls
- Security: I believe doc-browser should not listen to remote connections, so I've restricted it to localhost. If you disagree, one could probably create an option for the host
- Enabling devdocs css
- Enabling syntaxhighlighting of devdocs' codesnippets using prism.js (just like devdocs does upstream)
- Adding a new option `FocusOnSummon`. I frequently search for certain functions from my editor and am content with the first match doc-browser comes up with. So it is a lot less disruptive to have it open on a second screen but not moving keyboard focus over to doc-browser.

Thank you for your time, just let me know in case you disagree with any of the changes.

Regards
Simon